### PR TITLE
Add Matches signature with length parameter

### DIFF
--- a/Re2.Net/MatchCollection.cpp
+++ b/Re2.Net/MatchCollection.cpp
@@ -16,9 +16,10 @@ namespace Re2
 {
 namespace Net
 {
-    MatchCollection::MatchCollection(Match^ match)
+    MatchCollection::MatchCollection(Match^ match, int length)
     {
         _match   = match;
+        _length  = length;
         _matches = gcnew ArrayList();
         _done    = !match->Success;
         if(!_done)
@@ -39,7 +40,7 @@ namespace Net
         do
         {
             _match = _match->NextMatch();
-            if(!_match->Success)
+            if(!_match->Success || _match->Index + _match->Length > _length)
             {
                 _done = true;
                 return nullptr;

--- a/Re2.Net/MatchCollection.h
+++ b/Re2.Net/MatchCollection.h
@@ -36,6 +36,7 @@ namespace Net
         internal:
 
             int        _done;
+            int        _length;
             Match^     _match;
             ArrayList^ _matches;
         

--- a/Re2.Net/Regex.cpp
+++ b/Re2.Net/Regex.cpp
@@ -622,27 +622,39 @@ namespace Net
 
         #pragma region Matches
 
+        MatchCollection^ Regex::Matches(String^ input, int startIndex, int length)
+        {
+            return gcnew MatchCollection(this->Match(input, startIndex, length), length);
+        }
+
+
+        MatchCollection^ Regex::Matches(array<Byte>^ input, int startIndex, int length)
+        {
+            return gcnew MatchCollection(this->Match(input, startIndex, length), length);
+        }
+
+
         MatchCollection^ Regex::Matches(String^ input, int startIndex)
         {
-            return gcnew MatchCollection(this->Match(input, startIndex, input->Length - startIndex));
+            return gcnew MatchCollection(this->Match(input, startIndex, input->Length - startIndex), input->Length - startIndex);
         }
 
 
         MatchCollection^ Regex::Matches(array<Byte>^ input, int startIndex)
         {
-            return gcnew MatchCollection(this->Match(input, startIndex, input->Length - startIndex));
+            return gcnew MatchCollection(this->Match(input, startIndex, input->Length - startIndex), input->Length - startIndex);
         }
 
 
         MatchCollection^ Regex::Matches(String^ input)
         {
-            return gcnew MatchCollection(this->Match(input, 0, input->Length));
+            return gcnew MatchCollection(this->Match(input, 0, input->Length), input->Length);
         }
 
 
         MatchCollection^ Regex::Matches(array<Byte>^ input)
         {
-            return gcnew MatchCollection(this->Match(input, 0, input->Length));
+            return gcnew MatchCollection(this->Match(input, 0, input->Length), input->Length);
         }
 
 

--- a/Re2.Net/Regex.h
+++ b/Re2.Net/Regex.h
@@ -667,6 +667,50 @@ namespace Net
                 /// </summary>
                 /// <param name="input">The string to search for a match.</param>
                 /// <param name="startIndex">The input index at which to start the search.</param>
+                /// <param name="length">The input length at which to end the search.</param>
+                /// <returns>
+                ///     A collection of the <see cref="Re2::Net::Match"/> objects found by the search. If no matches are found, the method
+                ///     returns an empty collection object.
+                /// </returns>
+                /// <exception cref="System::ArgumentNullException">
+                ///     <paramref name="input"/> is <c>null</c>.
+                /// </exception>
+                /// <exception cref="System::ArgumentOutOfRangeException">
+                ///     <para><paramref name="startIndex"/> is less than zero or greater than the length of <paramref name="input"/>.</para>
+                ///     <para>- or -</para>
+                ///     <para><paramref name="input"/> is not a valid Latin-1 string (flag <c>RegexOptions.Latin1</c> is set).</para>
+                ///     <para>- or -</para>
+                ///     <para><paramref name="input"/> is not a valid ASCII string (flag <c>RegexOptions.ASCII</c> is set).</para>
+                /// </exception>
+                MatchCollection^ Matches(String^ input, int startIndex, int length);
+
+
+                /// <summary>
+                ///     Searches the specified input byte array for all occurrences of a regular expression, beginning at the specified
+                ///     starting position.
+                /// </summary>
+                /// <param name="input">The byte array to search for a match.</param>
+                /// <param name="startIndex">The input index at which to start the search.</param>
+                /// <param name="length">The input length at which to end the search.</param>
+                /// <returns>
+                ///     A collection of the <see cref="Re2::Net::Match"/> objects found by the search. If no matches are found, the method
+                ///     returns an empty collection object.
+                /// </returns>
+                /// <exception cref="System::ArgumentNullException">
+                ///     <paramref name="input"/> is <c>null</c>.
+                /// </exception>
+                /// <exception cref="System::ArgumentOutOfRangeException">
+                ///     <paramref name="startIndex"/> is less than zero or greater than the length of <paramref name="input"/>.
+                /// </exception>
+                MatchCollection^ Matches(array<Byte>^ input, int startIndex, int length);
+
+
+                /// <summary>
+                ///     Searches the specified input string for all occurrences of a regular expression, beginning at the specified
+                ///     starting position in the string.
+                /// </summary>
+                /// <param name="input">The string to search for a match.</param>
+                /// <param name="startIndex">The input index at which to start the search.</param>
                 /// <returns>
                 ///     A collection of the <see cref="Re2::Net::Match"/> objects found by the search. If no matches are found, the method
                 ///     returns an empty collection object.


### PR DESCRIPTION
When using a fixed buffer, the length of the search area is different from the length of the buffer. This enables sliding window algorithms.